### PR TITLE
Add udev rule to auto grant any user in users group access to the device

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,4 +23,7 @@ gm12u320
 6. Now trigger rebuild of initramfs:
 update-initramfs -u
 
+7. Most distros wont grant the user access rights to the framebuffer device. cd /dev && ls -la | grep fb1 will show the permitted group, typically 'video'. 
+Either add the user to this group or cp over the /etc/udev/rules.d file to automatically grant any user in users access to the device.
+
 It's done, have fun!

--- a/etc/udev/rules.d/12-acer_c120.rules
+++ b/etc/udev/rules.d/12-acer_c120.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="graphics", ATTRS{name}=="gm12u320", GROUP:="users"


### PR DESCRIPTION
Good day sir, just a small tweak to fix users needing to be in the video group. I'm also making a small gtk launcher that will run an app with a different $home to provide adhoc config for running videos on the device.

Is it possible to premote the driver over the usb-storage? There's a acpi background light driver in my repo list which does this but I haven't worked out how.

Rgs, Andrew
